### PR TITLE
'health' テーブルの定義

### DIFF
--- a/firebase/firestore.indexes.json
+++ b/firebase/firestore.indexes.json
@@ -1,4 +1,18 @@
 {
-  "indexes": [],
+  "indexes": [
+    {
+      "collectionId": "health",
+      "fields": [
+        {
+          "fieldPath": "userId",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "date",
+          "order": "ASCENDING"
+        }
+      ]
+    }
+  ],
   "fieldOverrides": []
 }

--- a/firebase/firestore.rules
+++ b/firebase/firestore.rules
@@ -54,5 +54,27 @@ service cloud.firestore {
         match /rankings/{document=**} {
             allow list: if true;
         }
+
+        match /health/{document=**} {
+            // 認証済み
+            allow read, write: if request.auth.uid != null;
+            // ユーザーは自分のデータのみアクセスを許可
+            allow read, write: if request.auth.uid == resource.data.user_id;
+            allow create, update: if (
+                isContainKeyInResourceData('userId')
+                && isContainKeyInResourceData('steps')
+                && isContainKeyInResourceData('distance')
+                && isContainKeyInResourceData('burnedCalorie')
+                && isContainKeyInResourceData('date')
+                && isContainKeyInResourceData('expiredAt')
+            );
+
+            // データの更新時、user_id が変更されていないことを確認
+            allow update: if request.resource.data.user_id == resource.data.user_id;
+
+            // expireAtを参照して削除できるように
+            allow delete: if true;
+        }
+
     }
 }

--- a/firebase/schema.yaml
+++ b/firebase/schema.yaml
@@ -30,15 +30,17 @@ users:
     totalSteps: int # アプリを利用し始めてからの合計歩数
     totalDistance: int # アプリを利用し始めてからの合計距離
   # 以下はお遍路に関する情報
-  pilgrimage: Map<string, dynamic>?
-    temple: ref<temples> # temples/:id
+  pilgrimage: Map<string, dynamic>
+    id: string # Firestoreのコレクションに付与するID。ユーザIDと同じ値
     lap: int # 何周目か
-    walkingDistance: int # 現在
+    movingDistance: int # 現在地点で歩行している距離。次の札所についたら0にリセットしてカウントし直す
+    nowPilgrimageId: int # 現在到達している札所の番号（1-88）
+    updatedAt: timestamp # 更新時刻
 
 ## お遍路の情報
 temples:
   documentId: int # お寺のID。お遍路の順路の番号を振る
-  templeName: string（お寺の名前）
+  templeName: string # お寺の名前
   prefecture: string # お寺の所在地の県
   address: string # 住所
   images: [string] # お寺の画像のURl一覧
@@ -47,16 +49,30 @@ temples:
     geohash: string
     geopoint: [double]
   distance: int # 次のお寺までに必要な距離
-  knowledge: string
+  knowledge: string # うんちく
   # そのほかお寺に必要な情報（TODO）
 
 ## ランキング情報
 rankings:
   documentId: string # daily, weekly, monthly のいずれか
-  users: List
-    rank: int # 順位
-    user: ref<users>
-    # 集計の都合上、ref<users> を利用するのが難しかったら以下を追加
-    # userId: string # uidで表現されたユーザID
-    # nickname: string # ニックネーム
-    # userIconUrl: string # ユーザアイコンのURL
+  distance: List<List<Map<string, int>>>
+    users: List<Map<string, int>>
+      rank: int # 順位
+      nickname: string # ニックネーム
+      userIconUrl: string # ユーザアイコンのURL
+      userId: string # ユーザID
+      value: int # 歩行距離
+  step: List<List<Map<string, int>>>
+    users: List<Map<string, int>>
+      rank: int # 順位
+      nickname: string # ニックネーム
+      userIconUrl: string # ユーザアイコンのURL
+      userId: string # ユーザID
+      value: int # 歩数
+  updatedTime: timestamp # 更新時刻(unixTime[ms])
+
+## 削除済みユーザ情報
+deleted_users:
+  documentId: string # 削除されたユーザのID
+  id: string # 削除されたユーザのID
+  deletedAt: timestamp # 削除日

--- a/firebase/schema.yaml
+++ b/firebase/schema.yaml
@@ -76,3 +76,15 @@ deleted_users:
   documentId: string # 削除されたユーザのID
   id: string # 削除されたユーザのID
   deletedAt: timestamp # 削除日
+
+## ヘルスケア情報
+### TTL機能を利用して、90日後に自動的に削除される
+### iOS, Android の Health 情報から取得する歩数情報を保存する
+health:
+  documentId: string # 自動生成されたID
+  userId: string # ユーザID
+  steps: int # 歩数
+  distance: int # 歩行距離
+  burnedCalorie: int # 消費カロリー
+  date: timestamp # ヘルスケア情報の日付
+  expiredAt: timestamp # ヘルスケア情報の有効期限(FirestoreのTTL機能を利用。dateの90日後)

--- a/lib/application/user/health/update_health_interactor.dart
+++ b/lib/application/user/health/update_health_interactor.dart
@@ -50,7 +50,7 @@ class UpdateHealthInteractor implements UpdateHealthUsecase {
       }
       await _userRepository.update(updatedUser);
       // 仮でここで更新している
-      // TODO: 日毎にヘルスケア情報を記録するように修正したら更新ロジック自体を見直す
+      // FIXME: 日毎にヘルスケア情報を記録するように修正したら更新ロジック自体を見直す
       await _userHealthRepository.update(
         UserHealth.createFromHealthByPeriod(
           user.id,

--- a/lib/application/user/health/update_health_interactor.dart
+++ b/lib/application/user/health/update_health_interactor.dart
@@ -5,22 +5,26 @@ import 'package:logger/logger.dart';
 import 'package:virtualpilgrimage/application/user/health/health_repository.dart';
 import 'package:virtualpilgrimage/application/user/health/update_health_result.codegen.dart';
 import 'package:virtualpilgrimage/application/user/health/update_health_usecase.dart';
+import 'package:virtualpilgrimage/application/user/health/user_health_repository.dart';
 import 'package:virtualpilgrimage/application/user/user_repository.dart';
 import 'package:virtualpilgrimage/domain/customizable_date_time.dart';
 import 'package:virtualpilgrimage/domain/exception/database_exception.dart';
 import 'package:virtualpilgrimage/domain/exception/get_health_exception.dart';
+import 'package:virtualpilgrimage/domain/health/user_health.codegen.dart';
 import 'package:virtualpilgrimage/domain/user/virtual_pilgrimage_user.codegen.dart';
 
 class UpdateHealthInteractor implements UpdateHealthUsecase {
   UpdateHealthInteractor(
     this._healthRepository,
     this._userRepository,
+    this._userHealthRepository,
     this._logger,
     this._crashlytics,
   );
 
   final HealthRepository _healthRepository;
   final UserRepository _userRepository;
+  final UserHealthRepository _userHealthRepository;
   final Logger _logger;
   final FirebaseCrashlytics _crashlytics;
 
@@ -45,6 +49,14 @@ class UpdateHealthInteractor implements UpdateHealthUsecase {
         );
       }
       await _userRepository.update(updatedUser);
+      // 仮でここで更新している
+      // TODO: 日毎にヘルスケア情報を記録するように修正したら更新ロジック自体を見直す
+      await _userHealthRepository.update(
+        UserHealth.createFromHealthByPeriod(
+          user.id,
+          (user.health != null && health.today.validate()) ? user.health!.today : health.today,
+        ),
+      );
     } on GetHealthException catch (e) {
       final message = 'get user health information error [user][$user][error][$e]';
       _logger.e(message);
@@ -123,5 +135,4 @@ class UpdateHealthInteractor implements UpdateHealthUsecase {
 
     return UpdateHealthResult(status: status, user: updatedUser, error: error);
   }
-
 }

--- a/lib/application/user/health/update_health_usecase.dart
+++ b/lib/application/user/health/update_health_usecase.dart
@@ -2,6 +2,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:virtualpilgrimage/application/user/health/health_repository.dart';
 import 'package:virtualpilgrimage/application/user/health/update_health_interactor.dart';
 import 'package:virtualpilgrimage/application/user/health/update_health_result.codegen.dart';
+import 'package:virtualpilgrimage/application/user/health/user_health_repository.dart';
 import 'package:virtualpilgrimage/application/user/user_repository.dart';
 import 'package:virtualpilgrimage/domain/user/virtual_pilgrimage_user.codegen.dart';
 import 'package:virtualpilgrimage/infrastructure/firebase/firebase_crashlytics_provider.dart';
@@ -11,6 +12,7 @@ final updateHealthUsecaseProvider = Provider.autoDispose<UpdateHealthUsecase>(
   (ref) => UpdateHealthInteractor(
     ref.read(healthRepositoryProvider),
     ref.read(userRepositoryProvider),
+    ref.read(userHealthRepositoryProvider),
     ref.read(loggerProvider),
     ref.read(firebaseCrashlyticsProvider),
   ),

--- a/lib/application/user/health/user_health_repository.dart
+++ b/lib/application/user/health/user_health_repository.dart
@@ -1,0 +1,18 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:virtualpilgrimage/domain/health/user_health.codegen.dart';
+import 'package:virtualpilgrimage/infrastructure/firebase/firestore_provider.dart';
+import 'package:virtualpilgrimage/infrastructure/health/user_health_repository_impl.dart';
+import 'package:virtualpilgrimage/logger.dart';
+
+final userHealthRepositoryProvider = Provider<UserHealthRepository>(
+  (ref) => UserHealthRepositoryImpl(ref.read(firestoreProvider), ref.read(loggerProvider)),
+);
+
+/// ユーザのヘルスケア情報を管理するリポジトリ
+abstract class UserHealthRepository {
+  /// ヘルスケア情報を作成・更新
+  Future<void> update(UserHealth userHealth);
+
+  /// 期間内のヘルスケア情報を取得
+  Future<List<UserHealth>> findHealthByPeriod(String userId, DateTime from, DateTime to);
+}

--- a/lib/domain/health/user_health.codegen.dart
+++ b/lib/domain/health/user_health.codegen.dart
@@ -1,0 +1,60 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:freezed_annotation/freezed_annotation.dart';
+import 'package:intl/intl.dart';
+import 'package:virtualpilgrimage/domain/customizable_date_time.dart';
+import 'package:virtualpilgrimage/domain/helper/firestore_timestamp_converter.dart';
+import 'package:virtualpilgrimage/domain/user/health/health_by_period.codegen.dart';
+
+part 'user_health.codegen.freezed.dart';
+part 'user_health.codegen.g.dart';
+
+@freezed
+class UserHealth with _$UserHealth {
+  @JsonSerializable()
+  const factory UserHealth({
+    // ユーザID
+    required String userId,
+    // 歩数
+    required int steps,
+    // 歩行距離
+    required int distance,
+    // 消費カロリー
+    required int burnedCalorie,
+    // 記録対象日
+    @JsonKey(
+      fromJson: FirestoreTimestampConverter.timestampToDateTime,
+      toJson: FirestoreTimestampConverter.dateTimeToTimestamp,
+    )
+        required DateTime date,
+    // 有効期限
+    @JsonKey(
+      fromJson: FirestoreTimestampConverter.timestampToDateTime,
+      toJson: FirestoreTimestampConverter.dateTimeToTimestamp,
+    )
+        required DateTime expiredAt,
+  }) = _UserHealth;
+
+  const UserHealth._();
+
+  factory UserHealth.fromJson(Map<String, dynamic> json) => _$UserHealthFromJson(json);
+
+  /// Firestore に保存する際のドキュメントID
+  String documentId() {
+    return '${userId}_${DateFormat('yyyyMMdd').format(date)}';
+  }
+
+  /// HealthByPeriod から UserHealth を作成する
+  // ignore: prefer_constructors_over_static_methods
+  static UserHealth createFromHealthByPeriod(String userId, HealthByPeriod healthByPeriod) {
+    final now = CustomizableDateTime.current;
+    return UserHealth(
+      userId: userId,
+      steps: healthByPeriod.steps,
+      distance: healthByPeriod.distance,
+      burnedCalorie: healthByPeriod.burnedCalorie,
+      date: DateTime(now.year, now.month, now.day),
+      // 90日間有効
+      expiredAt: DateTime(now.year, now.month, now.day).add(const Duration(days: 90)),
+    );
+  }
+}

--- a/lib/domain/health/user_health.codegen.freezed.dart
+++ b/lib/domain/health/user_health.codegen.freezed.dart
@@ -1,0 +1,295 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'user_health.codegen.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#custom-getters-and-methods');
+
+UserHealth _$UserHealthFromJson(Map<String, dynamic> json) {
+  return _UserHealth.fromJson(json);
+}
+
+/// @nodoc
+mixin _$UserHealth {
+// ユーザID
+  String get userId => throw _privateConstructorUsedError; // 歩数
+  int get steps => throw _privateConstructorUsedError; // 歩行距離
+  int get distance => throw _privateConstructorUsedError; // 消費カロリー
+  int get burnedCalorie => throw _privateConstructorUsedError; // 記録対象日
+  @JsonKey(
+      fromJson: FirestoreTimestampConverter.timestampToDateTime,
+      toJson: FirestoreTimestampConverter.dateTimeToTimestamp)
+  DateTime get date => throw _privateConstructorUsedError; // 有効期限
+  @JsonKey(
+      fromJson: FirestoreTimestampConverter.timestampToDateTime,
+      toJson: FirestoreTimestampConverter.dateTimeToTimestamp)
+  DateTime get expiredAt => throw _privateConstructorUsedError;
+
+  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
+  @JsonKey(ignore: true)
+  $UserHealthCopyWith<UserHealth> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $UserHealthCopyWith<$Res> {
+  factory $UserHealthCopyWith(
+          UserHealth value, $Res Function(UserHealth) then) =
+      _$UserHealthCopyWithImpl<$Res, UserHealth>;
+  @useResult
+  $Res call(
+      {String userId,
+      int steps,
+      int distance,
+      int burnedCalorie,
+      @JsonKey(fromJson: FirestoreTimestampConverter.timestampToDateTime, toJson: FirestoreTimestampConverter.dateTimeToTimestamp)
+          DateTime date,
+      @JsonKey(fromJson: FirestoreTimestampConverter.timestampToDateTime, toJson: FirestoreTimestampConverter.dateTimeToTimestamp)
+          DateTime expiredAt});
+}
+
+/// @nodoc
+class _$UserHealthCopyWithImpl<$Res, $Val extends UserHealth>
+    implements $UserHealthCopyWith<$Res> {
+  _$UserHealthCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? userId = null,
+    Object? steps = null,
+    Object? distance = null,
+    Object? burnedCalorie = null,
+    Object? date = null,
+    Object? expiredAt = null,
+  }) {
+    return _then(_value.copyWith(
+      userId: null == userId
+          ? _value.userId
+          : userId // ignore: cast_nullable_to_non_nullable
+              as String,
+      steps: null == steps
+          ? _value.steps
+          : steps // ignore: cast_nullable_to_non_nullable
+              as int,
+      distance: null == distance
+          ? _value.distance
+          : distance // ignore: cast_nullable_to_non_nullable
+              as int,
+      burnedCalorie: null == burnedCalorie
+          ? _value.burnedCalorie
+          : burnedCalorie // ignore: cast_nullable_to_non_nullable
+              as int,
+      date: null == date
+          ? _value.date
+          : date // ignore: cast_nullable_to_non_nullable
+              as DateTime,
+      expiredAt: null == expiredAt
+          ? _value.expiredAt
+          : expiredAt // ignore: cast_nullable_to_non_nullable
+              as DateTime,
+    ) as $Val);
+  }
+}
+
+/// @nodoc
+abstract class _$$_UserHealthCopyWith<$Res>
+    implements $UserHealthCopyWith<$Res> {
+  factory _$$_UserHealthCopyWith(
+          _$_UserHealth value, $Res Function(_$_UserHealth) then) =
+      __$$_UserHealthCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call(
+      {String userId,
+      int steps,
+      int distance,
+      int burnedCalorie,
+      @JsonKey(fromJson: FirestoreTimestampConverter.timestampToDateTime, toJson: FirestoreTimestampConverter.dateTimeToTimestamp)
+          DateTime date,
+      @JsonKey(fromJson: FirestoreTimestampConverter.timestampToDateTime, toJson: FirestoreTimestampConverter.dateTimeToTimestamp)
+          DateTime expiredAt});
+}
+
+/// @nodoc
+class __$$_UserHealthCopyWithImpl<$Res>
+    extends _$UserHealthCopyWithImpl<$Res, _$_UserHealth>
+    implements _$$_UserHealthCopyWith<$Res> {
+  __$$_UserHealthCopyWithImpl(
+      _$_UserHealth _value, $Res Function(_$_UserHealth) _then)
+      : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? userId = null,
+    Object? steps = null,
+    Object? distance = null,
+    Object? burnedCalorie = null,
+    Object? date = null,
+    Object? expiredAt = null,
+  }) {
+    return _then(_$_UserHealth(
+      userId: null == userId
+          ? _value.userId
+          : userId // ignore: cast_nullable_to_non_nullable
+              as String,
+      steps: null == steps
+          ? _value.steps
+          : steps // ignore: cast_nullable_to_non_nullable
+              as int,
+      distance: null == distance
+          ? _value.distance
+          : distance // ignore: cast_nullable_to_non_nullable
+              as int,
+      burnedCalorie: null == burnedCalorie
+          ? _value.burnedCalorie
+          : burnedCalorie // ignore: cast_nullable_to_non_nullable
+              as int,
+      date: null == date
+          ? _value.date
+          : date // ignore: cast_nullable_to_non_nullable
+              as DateTime,
+      expiredAt: null == expiredAt
+          ? _value.expiredAt
+          : expiredAt // ignore: cast_nullable_to_non_nullable
+              as DateTime,
+    ));
+  }
+}
+
+/// @nodoc
+
+@JsonSerializable()
+class _$_UserHealth extends _UserHealth {
+  const _$_UserHealth(
+      {required this.userId,
+      required this.steps,
+      required this.distance,
+      required this.burnedCalorie,
+      @JsonKey(fromJson: FirestoreTimestampConverter.timestampToDateTime, toJson: FirestoreTimestampConverter.dateTimeToTimestamp)
+          required this.date,
+      @JsonKey(fromJson: FirestoreTimestampConverter.timestampToDateTime, toJson: FirestoreTimestampConverter.dateTimeToTimestamp)
+          required this.expiredAt})
+      : super._();
+
+  factory _$_UserHealth.fromJson(Map<String, dynamic> json) =>
+      _$$_UserHealthFromJson(json);
+
+// ユーザID
+  @override
+  final String userId;
+// 歩数
+  @override
+  final int steps;
+// 歩行距離
+  @override
+  final int distance;
+// 消費カロリー
+  @override
+  final int burnedCalorie;
+// 記録対象日
+  @override
+  @JsonKey(
+      fromJson: FirestoreTimestampConverter.timestampToDateTime,
+      toJson: FirestoreTimestampConverter.dateTimeToTimestamp)
+  final DateTime date;
+// 有効期限
+  @override
+  @JsonKey(
+      fromJson: FirestoreTimestampConverter.timestampToDateTime,
+      toJson: FirestoreTimestampConverter.dateTimeToTimestamp)
+  final DateTime expiredAt;
+
+  @override
+  String toString() {
+    return 'UserHealth(userId: $userId, steps: $steps, distance: $distance, burnedCalorie: $burnedCalorie, date: $date, expiredAt: $expiredAt)';
+  }
+
+  @override
+  bool operator ==(dynamic other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$_UserHealth &&
+            (identical(other.userId, userId) || other.userId == userId) &&
+            (identical(other.steps, steps) || other.steps == steps) &&
+            (identical(other.distance, distance) ||
+                other.distance == distance) &&
+            (identical(other.burnedCalorie, burnedCalorie) ||
+                other.burnedCalorie == burnedCalorie) &&
+            (identical(other.date, date) || other.date == date) &&
+            (identical(other.expiredAt, expiredAt) ||
+                other.expiredAt == expiredAt));
+  }
+
+  @JsonKey(ignore: true)
+  @override
+  int get hashCode => Object.hash(
+      runtimeType, userId, steps, distance, burnedCalorie, date, expiredAt);
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$_UserHealthCopyWith<_$_UserHealth> get copyWith =>
+      __$$_UserHealthCopyWithImpl<_$_UserHealth>(this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$$_UserHealthToJson(
+      this,
+    );
+  }
+}
+
+abstract class _UserHealth extends UserHealth {
+  const factory _UserHealth(
+      {required final String userId,
+      required final int steps,
+      required final int distance,
+      required final int burnedCalorie,
+      @JsonKey(fromJson: FirestoreTimestampConverter.timestampToDateTime, toJson: FirestoreTimestampConverter.dateTimeToTimestamp)
+          required final DateTime date,
+      @JsonKey(fromJson: FirestoreTimestampConverter.timestampToDateTime, toJson: FirestoreTimestampConverter.dateTimeToTimestamp)
+          required final DateTime expiredAt}) = _$_UserHealth;
+  const _UserHealth._() : super._();
+
+  factory _UserHealth.fromJson(Map<String, dynamic> json) =
+      _$_UserHealth.fromJson;
+
+  @override // ユーザID
+  String get userId;
+  @override // 歩数
+  int get steps;
+  @override // 歩行距離
+  int get distance;
+  @override // 消費カロリー
+  int get burnedCalorie;
+  @override // 記録対象日
+  @JsonKey(
+      fromJson: FirestoreTimestampConverter.timestampToDateTime,
+      toJson: FirestoreTimestampConverter.dateTimeToTimestamp)
+  DateTime get date;
+  @override // 有効期限
+  @JsonKey(
+      fromJson: FirestoreTimestampConverter.timestampToDateTime,
+      toJson: FirestoreTimestampConverter.dateTimeToTimestamp)
+  DateTime get expiredAt;
+  @override
+  @JsonKey(ignore: true)
+  _$$_UserHealthCopyWith<_$_UserHealth> get copyWith =>
+      throw _privateConstructorUsedError;
+}

--- a/lib/domain/health/user_health.codegen.g.dart
+++ b/lib/domain/health/user_health.codegen.g.dart
@@ -1,0 +1,30 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'user_health.codegen.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_$_UserHealth _$$_UserHealthFromJson(Map<String, dynamic> json) =>
+    _$_UserHealth(
+      userId: json['userId'] as String,
+      steps: json['steps'] as int,
+      distance: json['distance'] as int,
+      burnedCalorie: json['burnedCalorie'] as int,
+      date: FirestoreTimestampConverter.timestampToDateTime(
+          json['date'] as Timestamp),
+      expiredAt: FirestoreTimestampConverter.timestampToDateTime(
+          json['expiredAt'] as Timestamp),
+    );
+
+Map<String, dynamic> _$$_UserHealthToJson(_$_UserHealth instance) =>
+    <String, dynamic>{
+      'userId': instance.userId,
+      'steps': instance.steps,
+      'distance': instance.distance,
+      'burnedCalorie': instance.burnedCalorie,
+      'date': FirestoreTimestampConverter.dateTimeToTimestamp(instance.date),
+      'expiredAt':
+          FirestoreTimestampConverter.dateTimeToTimestamp(instance.expiredAt),
+    };

--- a/lib/infrastructure/firebase/firestore_collection_path.dart
+++ b/lib/infrastructure/firebase/firestore_collection_path.dart
@@ -4,6 +4,5 @@ extension FirestoreCollectionPath on String {
   static const String temples = 'temples';
   static const String deletedUsers = 'deleted_users';
   static const String rankings = 'rankings';
-
-  static String health(String userId) => '$users/$userId/health';
+  static const String health = 'health';
 }

--- a/lib/infrastructure/health/user_health_repository_impl.dart
+++ b/lib/infrastructure/health/user_health_repository_impl.dart
@@ -1,0 +1,59 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:logger/logger.dart';
+import 'package:virtualpilgrimage/application/user/health/user_health_repository.dart';
+import 'package:virtualpilgrimage/domain/exception/database_exception.dart';
+import 'package:virtualpilgrimage/domain/health/user_health.codegen.dart';
+import 'package:virtualpilgrimage/infrastructure/firebase/firestore_collection_path.dart';
+
+class UserHealthRepositoryImpl extends UserHealthRepository {
+  UserHealthRepositoryImpl(this._firestoreClient, this._logger);
+
+  final FirebaseFirestore _firestoreClient;
+  final Logger _logger;
+
+  @override
+  Future<void> update(UserHealth userHealth) async {
+    try {
+      _logger.d('update user health to Firestore');
+      await _firestoreClient
+          .collection(FirestoreCollectionPath.health)
+          .doc(userHealth.documentId())
+          .set(userHealth.toJson());
+    } on FirebaseException catch (e) {
+      throw DatabaseException(
+        message: 'Failed with error [code][${e.code}][message][${e.message}]',
+        cause: e,
+      );
+    } on Exception catch (e) {
+      throw DatabaseException(message: 'unexpected error [error][$e]', cause: e);
+    }
+  }
+
+  // FIXME: interface に合うよう仮実装しているだけ
+  @override
+  Future<List<UserHealth>> findHealthByPeriod(String userId, DateTime from, DateTime to) async {
+    try {
+      _logger.d('find user health from Firestore');
+      final ref = _firestoreClient
+          .collection(FirestoreCollectionPath.health)
+          .where('userId', isEqualTo: userId)
+          .where('date', isGreaterThanOrEqualTo: from)
+          .where('date', isLessThanOrEqualTo: to)
+          .withConverter<UserHealth>(
+            fromFirestore: (DocumentSnapshot<Map<String, dynamic>> snapshot, _) =>
+                UserHealth.fromJson(snapshot.data()!),
+            toFirestore: (UserHealth userHealth, _) => userHealth.toJson(),
+          );
+      final snapshot = await ref.get();
+      final healths = snapshot.docs.map((e) => e.data()).toList();
+      return healths;
+    } on FirebaseException catch (e) {
+      throw DatabaseException(
+        message: 'Failed with error [code][${e.code}][message][${e.message}]',
+        cause: e,
+      );
+    } on Exception catch (e) {
+      throw DatabaseException(message: 'unexpected error [error][$e]', cause: e);
+    }
+  }
+}

--- a/lib/ui/pages/sign_in/sign_in_page.dart
+++ b/lib/ui/pages/sign_in/sign_in_page.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:io';
 
 import 'package:flutter/material.dart';
@@ -8,6 +9,7 @@ import 'package:virtualpilgrimage/analytics.dart';
 import 'package:virtualpilgrimage/application/user/user_repository.dart';
 import 'package:virtualpilgrimage/domain/user/virtual_pilgrimage_user.codegen.dart';
 import 'package:virtualpilgrimage/infrastructure/firebase/firebase_auth_provider.dart';
+import 'package:virtualpilgrimage/infrastructure/firebase/firebase_crashlytics_provider.dart';
 import 'package:virtualpilgrimage/ui/components/atoms/primary_button.dart';
 import 'package:virtualpilgrimage/ui/components/atoms/secondary_button.dart';
 import 'package:virtualpilgrimage/ui/components/my_app_bar.dart';
@@ -37,6 +39,7 @@ class _SignInPageState extends ConsumerState<SignInPage> {
       final analytics = ref.read(analyticsProvider);
       final userState = ref.read(userStateProvider.notifier);
       final loginState = ref.read(loginStateProvider.notifier);
+      final crashlytics = ref.read(firebaseCrashlyticsProvider);
 
       // FirebaseへのログインがキャッシュされていればFirestoreからユーザ情報を詰める
       if (firebaseAuth.currentUser != null && userState.state == null) {
@@ -46,6 +49,8 @@ class _SignInPageState extends ConsumerState<SignInPage> {
             userState.state = value;
             loginState.state = value.userStatus;
           }
+        }).onError((error, stackTrace) {
+          unawaited(crashlytics.recordError(error, stackTrace));
         });
       }
 

--- a/test/application/user/health/update_health_interactor_test.dart
+++ b/test/application/user/health/update_health_interactor_test.dart
@@ -20,6 +20,7 @@ import '../../../helper/provider_container.dart';
 void main() {
   late MockHealthRepository mockHealthRepository;
   late MockUserRepository mockUserRepository;
+  late MockUserHealthRepository mockUserHealthRepository;
   late MockFirebaseCrashlytics mockFirebaseCrashlytics;
   final logger = Logger(level: Level.nothing);
 
@@ -28,10 +29,12 @@ void main() {
   setUp(() {
     mockHealthRepository = MockHealthRepository();
     mockUserRepository = MockUserRepository();
+    mockUserHealthRepository = MockUserHealthRepository();
     mockFirebaseCrashlytics = MockFirebaseCrashlytics();
     target = UpdateHealthInteractor(
       mockHealthRepository,
       mockUserRepository,
+      mockUserHealthRepository,
       logger,
       mockFirebaseCrashlytics,
     );

--- a/test/helper/fakes/fake_user_health_repository.dart
+++ b/test/helper/fakes/fake_user_health_repository.dart
@@ -1,0 +1,15 @@
+import 'package:virtualpilgrimage/application/user/health/user_health_repository.dart';
+import 'package:virtualpilgrimage/domain/health/user_health.codegen.dart';
+
+class FakeUserHealthRepository extends UserHealthRepository {
+  @override
+  Future<List<UserHealth>> findHealthByPeriod(String userId, DateTime from, DateTime to) {
+    // TODO: implement findHealthByPeriod
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<void> update(UserHealth userHealth) {
+    return Future.value();
+  }
+}

--- a/test/helper/fakes/fake_user_health_repository.dart
+++ b/test/helper/fakes/fake_user_health_repository.dart
@@ -4,7 +4,7 @@ import 'package:virtualpilgrimage/domain/health/user_health.codegen.dart';
 class FakeUserHealthRepository extends UserHealthRepository {
   @override
   Future<List<UserHealth>> findHealthByPeriod(String userId, DateTime from, DateTime to) {
-    // TODO: implement findHealthByPeriod
+    // FIXME: implement findHealthByPeriod
     throw UnimplementedError();
   }
 

--- a/test/helper/mock.dart
+++ b/test/helper/mock.dart
@@ -13,6 +13,7 @@ import 'package:package_info/package_info.dart';
 import 'package:virtualpilgrimage/application/auth/reset_password_usecase.dart';
 import 'package:virtualpilgrimage/application/ranking/ranking_repository.dart';
 import 'package:virtualpilgrimage/application/user/health/health_repository.dart';
+import 'package:virtualpilgrimage/application/user/health/user_health_repository.dart';
 import 'package:virtualpilgrimage/application/user/profile/user_profile_image_repository.dart';
 import 'package:virtualpilgrimage/application/user/user_repository.dart';
 import 'package:virtualpilgrimage/infrastructure/auth/apple_auth_repository.dart';
@@ -63,6 +64,7 @@ import 'package:virtualpilgrimage/infrastructure/auth/google_auth_repository.dar
   HealthRepository,
   UserProfileImageRepository,
   RankingRepository,
+  UserHealthRepository,
 
   /// UseCases
   ResetUserPasswordUsecase,

--- a/test/ui/pages/profile/profile_presenter_test.dart
+++ b/test/ui/pages/profile/profile_presenter_test.dart
@@ -1,6 +1,7 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:virtualpilgrimage/application/user/health/health_repository.dart';
+import 'package:virtualpilgrimage/application/user/health/user_health_repository.dart';
 import 'package:virtualpilgrimage/application/user/user_repository.dart';
 import 'package:virtualpilgrimage/domain/customizable_date_time.dart';
 import 'package:virtualpilgrimage/domain/pilgrimage/pilgrimage_info.codegen.dart';
@@ -11,6 +12,7 @@ import 'package:virtualpilgrimage/ui/pages/profile/profile_presenter.dart';
 import 'package:virtualpilgrimage/ui/pages/profile/profile_state.codegen.dart';
 
 import '../../../helper/fakes/fake_health_repository.dart';
+import '../../../helper/fakes/fake_user_health_repository.dart';
 import '../../../helper/fakes/fake_user_repository.dart';
 import '../../../helper/provider_container.dart';
 
@@ -76,6 +78,7 @@ void main() {
       container = mockedProviderContainer(
         overrides: [
           userRepositoryProvider.overrideWithValue(FakeUserRepository(loginUser)),
+          userHealthRepositoryProvider.overrideWithValue(FakeUserHealthRepository()),
           healthRepositoryProvider.overrideWithValue(healthRepository),
         ],
       );
@@ -83,7 +86,8 @@ void main() {
       final actualLoading = container.read(profileUserProvider('dummyLoginUserId'));
       expect(actualLoading, const AsyncValue<VirtualPilgrimageUser?>.loading());
 
-      // UseCaseでの更新処理と取得処理の2つをawaitするため、2回記述
+      // UseCaseでの更新処理と取得処理の3つをawaitするため、3回 + UseCase の async 待ちの4回 await
+      await Future<void>.value();
       await Future<void>.value();
       await Future<void>.value();
       await Future<void>.value();


### PR DESCRIPTION
@sports-club-hanzan/developer 

どうしても OS ごとの  health ケア情報取得・更新が重いことや日毎のヘルスケア情報を保存しておいていないことでアプリの機能拡張ができないので `health` テーブルを新設し、日毎にユーザのヘルスケア情報を保存します