### PR TITLE
ユーザ情報の当日のヘルスケア情報を保存できない問題を解消

### DIFF
--- a/lib/application/pilgrimage/update_pilgrimage_progress_interactor.dart
+++ b/lib/application/pilgrimage/update_pilgrimage_progress_interactor.dart
@@ -99,7 +99,7 @@ class UpdatePilgrimageProgressInteractor extends UpdatePilgrimageProgressUsecase
     DateTime now,
     List<int> reachedPilgrimageIdList,
   ) async {
-    final lastProgressUpdatedAt = user.updatedAt; // user.pilgrimage.updatedAt;
+    final lastProgressUpdatedAt = user.updatedAt;
     final int nextPilgrimageId = user.pilgrimage.nowPilgrimageId;
 
     _logger.d(
@@ -145,16 +145,17 @@ class UpdatePilgrimageProgressInteractor extends UpdatePilgrimageProgressUsecase
     }
 
     /// 2. 最後に保存した日毎のヘルスケア情報を取得
+    /// 3 で上書きされるので、この時点で保持しておく
     final lastHealth = await _userHealthRepository.find(user.id, lastProgressUpdatedAt);
 
-    /// 2. 非同期でユーザのヘルスケア情報を更新
+    /// 3. 非同期でユーザのヘルスケア情報を更新
     final updatedUser = await _updateUserHealth(
       user: user,
       healthAggregationResult: healthAggregationResult,
       now: now,
     );
 
-    /// 3. 移動距離 > 次の札所までの距離 の間、で移動距離を減らしながら次に目指すべき札所を導出する
+    /// 4. 移動距離 > 次の札所までの距離 の間、で移動距離を減らしながら次に目指すべき札所を導出する
     return _updateUserPilgrimageProgress(
       user: updatedUser,
       healthAggregationResult: healthAggregationResult,
@@ -195,7 +196,7 @@ class UpdatePilgrimageProgressInteractor extends UpdatePilgrimageProgressUsecase
       // 仮に情報が存在する場合も上書きする
       final target = UserHealth.createFromHealthByPeriod(
         userId: user.id,
-        day: key,
+        day: DateTime(key.year, key.month, key.day),
         healthByPeriod: value,
       );
       _logger.d('save health [target][$target][date][$key]');

--- a/lib/infrastructure/user/health_repository_impl.dart
+++ b/lib/infrastructure/user/health_repository_impl.dart
@@ -366,8 +366,6 @@ class HealthRepositoryImpl implements HealthRepository {
       aggregateResult[target] = result.add(p.value);
     }
 
-    print(points);
-    print(aggregateResult);
     return aggregateResult;
   }
 

--- a/lib/infrastructure/user/health_repository_impl.dart
+++ b/lib/infrastructure/user/health_repository_impl.dart
@@ -117,11 +117,9 @@ class HealthRepositoryImpl implements HealthRepository {
           dt = dtStartTime;
         }
         final health = await _getHealthData(
-            dt,
-            dtStartTime
-                .add(const Duration(days: 1))
-                .subtract(const Duration(microseconds: 1)),
-            types,
+          dt,
+          dtStartTime.add(const Duration(days: 1)).subtract(const Duration(microseconds: 1)),
+          types,
         );
         eachDay[dtStartTime] = _aggregateHealthInfo(health);
       }

--- a/test/application/pilgrimage/update_pilgrimage_progress_interactor_test.dart
+++ b/test/application/pilgrimage/update_pilgrimage_progress_interactor_test.dart
@@ -72,7 +72,7 @@ void main() {
         // healthのスタブ
         when(
           healthRepository.aggregateHealthByPeriod(
-            from: DateTime.utc(2022),
+            from: DateTime(2022, 3, 31),
             to: CustomizableDateTime.current,
           ),
         ).thenAnswer(
@@ -93,25 +93,19 @@ void main() {
           ),
         );
 
-        // 日毎のhealthを更新するときのモック
-        when(userHealthRepository.find('dummyId', DateTime(2022, 3, 31))).thenAnswer(
+        // 最後に保存したhealthを取得するstub
+        when(userHealthRepository.find('dummyId', DateTime(2022, 3, 31, 22))).thenAnswer(
           (_) => Future.value(
             UserHealth(
               userId: 'dummyId',
-              date: DateTime(2022, 3, 31),
-              steps: 1000,
-              distance: 500,
-              burnedCalorie: 100,
-              expiredAt: DateTime(2022, 6, 29),
+              date: DateTime(2022, 1, 1),
+              steps: 10,
+              distance: 10,
+              burnedCalorie: 10,
+              expiredAt: DateTime(2022, 4, 1),
             ),
           ),
         );
-        when(userHealthRepository.find('dummyId', DateTime(2022, 4, 1)))
-            .thenAnswer((_) => Future.value(null));
-        when(userHealthRepository.find('dummyId', DateTime(2022, 4, 2)))
-            .thenAnswer((_) => Future.value(null));
-        when(userHealthRepository.find('dummyId', DateTime(2022, 4, 3)))
-            .thenAnswer((_) => Future.value(null));
       });
 
       test('正常系', () async {
@@ -129,9 +123,12 @@ void main() {
             ),
             updatedAt: CustomizableDateTime.current,
             pilgrimage: user.pilgrimage.copyWith(
-              nowPilgrimageId: 2, // 87 -> 88(スタート地点がリセットされて1) -> 2
-              lap: 2, // 88にたどり着いたのでlap++
-              movingDistance: 1600 + 100, // (27000 - (7000 + 17000 + 1400)) + 100(元々ユーザ情報に保持していた距離)
+              nowPilgrimageId: 2,
+              // 87 -> 88(スタート地点がリセットされて1) -> 2
+              lap: 2,
+              // 88にたどり着いたのでlap++
+              movingDistance: 1600 + 110 - 10,
+              // (27000 - (7000 + 17000 + 1400)) + 110(元々ユーザ情報に保持していた距離) - 10(最後に保存した日毎の歩行距離)
               updatedAt: CustomizableDateTime.current,
             ),
           ),
@@ -154,7 +151,7 @@ void main() {
           verify(templeRepository.getTempleInfo(86)).called(1);
           verify(
             healthRepository.aggregateHealthByPeriod(
-              from: user.updatedAt,
+              from: DateTime(2022, 3, 31),
               to: CustomizableDateTime.current,
             ),
           );
@@ -170,9 +167,9 @@ void main() {
               UserHealth(
                 userId: 'dummyId',
                 date: DateTime(2022, 3, 31),
-                steps: 11000,
-                distance: 10500,
-                burnedCalorie: 600,
+                steps: 10000,
+                distance: 10000,
+                burnedCalorie: 500,
                 expiredAt: DateTime(2022, 6, 29),
               ),
             ),
@@ -250,9 +247,12 @@ void main() {
             ),
             updatedAt: CustomizableDateTime.current,
             pilgrimage: user.pilgrimage.copyWith(
-              nowPilgrimageId: 2, // 87 -> 88(スタート地点がリセットされて1) -> 2
-              lap: 2, // 88にたどり着いたのでlap++
-              movingDistance: 1600 + 100, // (27000 - (7000 + 17000 + 1400)) + 100(元々ユーザ情報に保持していた距離)
+              nowPilgrimageId: 2,
+              // 87 -> 88(スタート地点がリセットされて1) -> 2
+              lap: 2,
+              // 88にたどり着いたのでlap++
+              movingDistance: 1600 + 110 - 10,
+              // (27000 - (7000 + 17000 + 1400)) + 110(元々ユーザ情報に保持していた距離) - 10(最後に保存した日毎の歩行距離)
               updatedAt: CustomizableDateTime.current,
             ),
           ),
@@ -280,12 +280,12 @@ VirtualPilgrimageUser defaultUser() {
     userIconUrl: '',
     userStatus: UserStatus.created,
     createdAt: DateTime.utc(2022),
-    updatedAt: DateTime.utc(2022),
+    updatedAt: DateTime(2022, 3, 31, 22),
     pilgrimage: PilgrimageInfo(
       id: 'dummyId',
       nowPilgrimageId: 86,
       updatedAt: DateTime.utc(2022),
-      movingDistance: 100,
+      movingDistance: 110,
     ),
     health: HealthInfo(
       today: HealthByPeriod.getDefault(),

--- a/test/infrastructure/health/health_repository_impl_test.dart
+++ b/test/infrastructure/health/health_repository_impl_test.dart
@@ -258,55 +258,54 @@ void main() {
       });
     });
 
-    group('getHealthByPeriod', () {
+    group('aggregateHealthByPeriod', () {
       test('正常系', () async {
         // given
         /// 今日
         when(
           mockHealthFactory.getHealthDataFromTypes(
-            targetDateTime,
-            DateTime(2022, 9, 19, 23, 59, 59, 999, 999),
+            DateTime(2022, 9, 18, 11, 0, 0, 0, 0),
+            DateTime(2022, 9, 18, 23, 59, 59, 999, 999),
             types,
           ),
         ).thenAnswer(
           (_) => Future.value([
                 // @formatter:off
-            HealthDataPoint(NumericHealthValue(468), HealthDataType.ACTIVE_ENERGY_BURNED, HealthDataUnit.KILOCALORIE, DateTime(2022, 9, 12), DateTime(2022, 9, 18), PlatformType.ANDROID, defaultDeviceId, defaultSourceId, defaultSourceName),
-            HealthDataPoint(NumericHealthValue(427), HealthDataType.STEPS, HealthDataUnit.COUNT, DateTime(2022, 9, 12), DateTime(2022, 9, 18), PlatformType.ANDROID, defaultDeviceId, defaultSourceId, defaultSourceName),
-            HealthDataPoint(NumericHealthValue(670), HealthDataType.DISTANCE_DELTA, HealthDataUnit.METER, DateTime(2022, 9, 12), DateTime(2022, 9, 18), PlatformType.ANDROID, defaultDeviceId, defaultSourceId, defaultSourceName),
-            HealthDataPoint(NumericHealthValue(1000), HealthDataType.ACTIVE_ENERGY_BURNED, HealthDataUnit.KILOCALORIE, DateTime(2022, 9, 19), DateTime(2022, 9, 20), PlatformType.ANDROID, defaultDeviceId, defaultSourceId, defaultSourceName),
-            HealthDataPoint(NumericHealthValue(1000), HealthDataType.STEPS, HealthDataUnit.COUNT, DateTime(2022, 9, 19), DateTime(2022, 9, 20), PlatformType.ANDROID, defaultDeviceId, defaultSourceId, defaultSourceName),
-            HealthDataPoint(NumericHealthValue(1000), HealthDataType.DISTANCE_DELTA, HealthDataUnit.METER, DateTime(2022, 9, 19), DateTime(2022, 9, 20), PlatformType.ANDROID, defaultDeviceId, defaultSourceId, defaultSourceName),
-            HealthDataPoint(NumericHealthValue(2000), HealthDataType.ACTIVE_ENERGY_BURNED, HealthDataUnit.KILOCALORIE, DateTime(2022, 9, 19), DateTime(2022, 9, 20), PlatformType.ANDROID, defaultDeviceId, defaultSourceId, defaultSourceName),
-            HealthDataPoint(NumericHealthValue(2000), HealthDataType.STEPS, HealthDataUnit.COUNT, DateTime(2022, 9, 19), DateTime(2022, 9, 20), PlatformType.ANDROID, defaultDeviceId, defaultSourceId, defaultSourceName),
-            HealthDataPoint(NumericHealthValue(2000), HealthDataType.DISTANCE_DELTA, HealthDataUnit.METER, DateTime(2022, 9, 19), DateTime(2022, 9, 20), PlatformType.ANDROID, defaultDeviceId, defaultSourceId, defaultSourceName),
+            HealthDataPoint(NumericHealthValue(468), HealthDataType.ACTIVE_ENERGY_BURNED, HealthDataUnit.KILOCALORIE, DateTime(2022, 9, 18), DateTime(2022, 9, 18), PlatformType.ANDROID, defaultDeviceId, defaultSourceId, defaultSourceName),
+            HealthDataPoint(NumericHealthValue(427), HealthDataType.STEPS, HealthDataUnit.COUNT, DateTime(2022, 9, 18), DateTime(2022, 9, 18), PlatformType.ANDROID, defaultDeviceId, defaultSourceId, defaultSourceName),
+            HealthDataPoint(NumericHealthValue(670), HealthDataType.DISTANCE_DELTA, HealthDataUnit.METER, DateTime(2022, 9, 18), DateTime(2022, 9, 18), PlatformType.ANDROID, defaultDeviceId, defaultSourceId, defaultSourceName),
             // @formatter:on
           ]),
         );
+        when(mockHealthFactory.getHealthDataFromTypes(
+                DateTime(2022, 9, 19), DateTime(2022, 9, 19, 23, 59, 59, 999, 999), types))
+            .thenAnswer((realInvocation) => Future.value([
+              // @formatter:off
+          HealthDataPoint(NumericHealthValue(1000), HealthDataType.ACTIVE_ENERGY_BURNED, HealthDataUnit.KILOCALORIE, DateTime(2022, 9, 19), DateTime(2022, 9, 20), PlatformType.ANDROID, defaultDeviceId, defaultSourceId + "_dummy", defaultSourceName),
+          HealthDataPoint(NumericHealthValue(1000), HealthDataType.STEPS, HealthDataUnit.COUNT, DateTime(2022, 9, 19), DateTime(2022, 9, 20), PlatformType.ANDROID, defaultDeviceId, defaultSourceId + "_dummy", defaultSourceName),
+          HealthDataPoint(NumericHealthValue(1000), HealthDataType.DISTANCE_DELTA, HealthDataUnit.METER, DateTime(2022, 9, 19), DateTime(2022, 9, 20), PlatformType.ANDROID, defaultDeviceId, defaultSourceId + "_dummy", defaultSourceName),
+          HealthDataPoint(NumericHealthValue(2000), HealthDataType.ACTIVE_ENERGY_BURNED, HealthDataUnit.KILOCALORIE, DateTime(2022, 9, 19), DateTime(2022, 9, 20), PlatformType.ANDROID, defaultDeviceId, defaultSourceId, defaultSourceName),
+          HealthDataPoint(NumericHealthValue(2000), HealthDataType.STEPS, HealthDataUnit.COUNT, DateTime(2022, 9, 19), DateTime(2022, 9, 20), PlatformType.ANDROID, defaultDeviceId, defaultSourceId, defaultSourceName),
+          HealthDataPoint(NumericHealthValue(2000), HealthDataType.DISTANCE_DELTA, HealthDataUnit.METER, DateTime(2022, 9, 19), DateTime(2022, 9, 20), PlatformType.ANDROID, defaultDeviceId, defaultSourceId, defaultSourceName),
+                  // @formatter:on
+                ]));
 
         // when
         final actual = await target.aggregateHealthByPeriod(
-          from: targetDateTime,
-          to: targetToDate.add(const Duration(days: 1)),
+          from: DateTime(2022, 9, 18, 11),
+          to: DateTime(2022, 9, 19, 23, 59, 59, 999, 999),
         );
 
         // then
         final expected = HealthAggregationResult(
           eachDay: {
-            DateTime(2022, 9, 12): HealthByPeriod(steps: 427, distance: 670, burnedCalorie: 468),
+            DateTime(2022, 9, 18): HealthByPeriod(steps: 427, distance: 670, burnedCalorie: 468),
             DateTime(2022, 9, 19): HealthByPeriod(steps: 2000, distance: 2000, burnedCalorie: 2000),
           },
           total: HealthByPeriod(steps: 2427, distance: 2670, burnedCalorie: 2468),
         );
         expect(actual, expected);
         verify(mockHealthFactory.requestAuthorization(any)).called(1);
-        verify(
-          mockHealthFactory.getHealthDataFromTypes(
-            targetDateTime,
-            targetToDate.add(const Duration(days: 1)),
-            types,
-          ),
-        ).called(1);
       });
     });
   });


### PR DESCRIPTION
非同期に日毎のユーザのヘルスケア情報を更新していたことで、当日のヘルスケア情報が保存されていない問題を修正しました。